### PR TITLE
Feat/캠페인 등록 기능 구현

### DIFF
--- a/src/components/MyProfile/ProfileInfo.jsx
+++ b/src/components/MyProfile/ProfileInfo.jsx
@@ -74,24 +74,16 @@ function ProfileInfo() {
             <img src={Message} alt="메시지 보내기" />
           </CircleBtn>
         </Link>
-        <Button
-          size="md"
-          active={true}
-          onClick={() => {
-            console.log('프로필 수정 페이지로 이동');
-          }}
-        >
-          프로필 수정
-        </Button>
-        <Button
-          size="md"
-          active={true}
-          onClick={() => {
-            console.log('할동 등록 페이지로 이동');
-          }}
-        >
-          활동 등록
-        </Button>
+        <Link to="/profilemodify">
+          <Button size="md" active={true}>
+            프로필 수정
+          </Button>
+        </Link>
+        <Link to="/campaign">
+          <Button size="md" active={true}>
+            활동 등록
+          </Button>
+        </Link>
         <CircleBtn>
           <img src={Share} alt="공유하기" />
         </CircleBtn>

--- a/src/components/Navbar/TopNavbar.jsx
+++ b/src/components/Navbar/TopNavbar.jsx
@@ -31,7 +31,9 @@ const TopMainNav = (props) => (
 const TopUploadNav = (props) => (
   <StyledTopBasicNav>
     <img src={iconArrowLeft} alt="뒤로가기" />
-    <Button size="sm">{props.value}</Button>
+    <Button size="sm" disabled={props.disabled} onClick={props.onClick}>
+      {props.value}
+    </Button>
   </StyledTopBasicNav>
 );
 

--- a/src/components/Navbar/styled.jsx
+++ b/src/components/Navbar/styled.jsx
@@ -33,7 +33,6 @@ const StyledTopBasicNav = styled.nav`
     bottom: 8px;
   }
   button {
-    background-color: ${({ theme }) => theme.colors.lightGreen};
     color: white;
     position: absolute;
     right: 16px;

--- a/src/pages/Campaign/CampaignPage.jsx
+++ b/src/pages/Campaign/CampaignPage.jsx
@@ -1,45 +1,193 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { TopUploadNav } from '../../components/Navbar/TopNavbar';
 import TextInput from '../../components/TextInput/TextInput';
 import { StyledCamoaignHeader, StyledCampaignInput } from './styled';
+import useAuthContext from '../../hooks/useAuthContext';
 
-const CampaignPage = () => (
-  <>
-    <StyledCamoaignHeader>
-      <h2 className="ir">캠페인 등록 페이지</h2>
-      <TopUploadNav value="저장"></TopUploadNav>
-    </StyledCamoaignHeader>
-    <StyledCampaignInput>
-      <form>
-        <div className="campaign-img-upload">
-          <h3>캠페인 등록</h3>
-          <label htmlFor="campaignImg" className="campaign-img-label"></label>
-          <input type="file" id="campaignImg" className="ir" />
-        </div>
-        <TextInput
-          label="상품명"
-          id="campaign-name"
-          type="string"
-          placeholder="2~10자 이내여야 합니다"
-          required
-        ></TextInput>
-        <TextInput
-          label="인원"
-          id="campaign-people"
-          type="number"
-          placeholder="ex) 00 명"
-          required
-        ></TextInput>
-        <TextInput
-          label="상세정보"
-          id="campaign-link"
-          type="url"
-          placeholder="URL을 입력해 주세요"
-          required
-        ></TextInput>
-      </form>
-    </StyledCampaignInput>
-  </>
-);
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
 
-export default CampaignPage;
+export default function CampaignPage() {
+  const [files, setFiles] = useState(null);
+  const [campaignName, setCampaignName] = useState('');
+  const [campaignPeople, setCampaignPeople] = useState('');
+  const [campaignLink, setCampaignLink] = useState('');
+
+  const [isVaildCampignImg, setIsValidCampaignImg] = useState(false);
+  const [isValidCampaignName, setIsValidCampaignName] = useState(false);
+  const [checkCampaignNameMsg, setCheckCampaignNameMsg] = useState('');
+  const [isValidCampaignPeople, setIsValidCampaignPeople] = useState(false);
+  const [checkCampaignPeopleMsg, setCheckCampaignPeopleMsg] = useState('');
+  const [isValidCampaignLink, setIsValidCampaignLink] = useState(false);
+  const [checkCampaignLinkMsg, setCheckCampaignLinkMsg] = useState('');
+
+  const navigate = useNavigate();
+
+  const { auth } = useAuthContext();
+
+  const passed =
+    isVaildCampignImg &&
+    isValidCampaignName &&
+    isValidCampaignLink &&
+    isValidCampaignPeople;
+
+  const handleCampaignImg = (e) => {
+    const file = e.target.files[0];
+    const formData = new FormData();
+
+    formData.append('image', file);
+
+    const imgUpload = async () => {
+      const res = await fetch(`${BASEURL}/image/uploadfile`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      const json = await res.json();
+
+      // 이미지 파일형식이 아닌 경우 에러 처리 ex) .svg
+      if (!json.filename) {
+        setFiles(null);
+
+        return;
+      }
+      setFiles(`${BASEURL}/${json.filename}`);
+    };
+
+    imgUpload();
+    setFiles(file);
+
+    if (file.name !== '') {
+      setIsValidCampaignImg(true);
+    }
+  };
+
+  const handleCampaignName = (e) => {
+    const targetName = e.target.value;
+
+    setCampaignName(e.target.value);
+    if (
+      targetName.length > 10 ||
+      (targetName.length < 2 && targetName !== '')
+    ) {
+      setCheckCampaignNameMsg('2자~10자 이내여야 합니다.');
+      setIsValidCampaignName(false);
+    } else {
+      setCheckCampaignNameMsg('');
+      setIsValidCampaignName(true);
+    }
+  };
+
+  const handleCampaignPeople = (e) => {
+    const targetPeople = e.target.value;
+
+    if (targetPeople < 1) {
+      setCheckCampaignPeopleMsg('1명 이상의 인원이 있어야 합니다.');
+      setIsValidCampaignPeople(false);
+    } else {
+      setCheckCampaignPeopleMsg('');
+      setIsValidCampaignPeople(true);
+    }
+
+    setCampaignPeople(e.target.value);
+  };
+
+  const handleCampaignLink = (e) => {
+    const targetLink = e.target.value;
+
+    setCampaignLink(e.target.value);
+    const regExp =
+      /^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/;
+
+    if (!regExp.test(targetLink) && targetLink !== '') {
+      setCheckCampaignLinkMsg('url형식에 맞지 않습니다.');
+      setIsValidCampaignLink(false);
+    } else if (targetLink === '') {
+      setCheckCampaignLinkMsg('유효한 url 주소를 입력하세요.');
+      setIsValidCampaignLink(false);
+    } else {
+      setCheckCampaignLinkMsg('');
+      setIsValidCampaignLink(true);
+    }
+  };
+
+  const data = {
+    itemName: campaignName,
+    price: Number(campaignPeople),
+    link: campaignLink,
+    itemImage: files,
+  };
+
+  const onSubmit = async () => {
+    const userData = { product: data };
+
+    const campaignUpload = await fetch(`${BASEURL}/product`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(userData),
+    });
+
+    navigate(`/myprofile`);
+
+    const result = campaignUpload.json();
+
+    if (result.status === 422) {
+      console.log(result.message);
+    }
+  };
+
+  return (
+    <>
+      <StyledCampaignInput>
+        <TopUploadNav disabled={!passed} onClick={onSubmit} value="저장" />
+        <form>
+          <div className="campaign-img-upload">
+            <h2>캠페인 등록</h2>
+            <label htmlFor="campaignImg" className="campaign-img-label">
+              <img src={files} alt="" />
+            </label>
+            <input
+              type="file"
+              id="campaignImg"
+              accept="image/*"
+              onChange={handleCampaignImg}
+            />
+          </div>
+          <TextInput
+            label="캠페인 이름"
+            id="campaign-name"
+            value={campaignName}
+            onChange={handleCampaignName}
+            type="string"
+            placeholder="2~10자 이내여야 합니다"
+            required
+          />
+          <p className="error-message">{checkCampaignNameMsg}</p>
+          <TextInput
+            label="인원"
+            id="campaign-people"
+            value={campaignPeople}
+            onChange={handleCampaignPeople}
+            type="number"
+            placeholder="ex) 00 명"
+            required
+          />
+          <p className="error-message">{checkCampaignPeopleMsg}</p>
+          <TextInput
+            label="상세정보"
+            id="campaign-link"
+            value={campaignLink}
+            onChange={handleCampaignLink}
+            type="url"
+            placeholder="URL을 입력해 주세요"
+            required
+          />
+          <p className="error-message">{checkCampaignLinkMsg}</p>
+        </form>
+      </StyledCampaignInput>
+    </>
+  );
+}

--- a/src/pages/Campaign/styled.jsx
+++ b/src/pages/Campaign/styled.jsx
@@ -1,29 +1,17 @@
 import styled from 'styled-components';
 import iconimgbutton from '../../assets/icon/icon-img-button-gray.svg';
 
-const StyledCamoaignHeader = styled.header`
-  .ir {
-    display: block;
-    overflow: hidden;
-    font-size: 1px;
-    line-height: 0;
-    text-indent: -9999px;
-  }
-`;
+const StyledCamoaignHeader = styled.header``;
 
 const StyledCampaignInput = styled.main`
   height: 796px;
   border: 1px solid black;
 
-  .ir {
-    display: block;
-    overflow: hidden;
-    font-size: 1px;
-    line-height: 0;
-    text-indent: -9999px;
+  #campaignImg {
+    display: none;
   }
 
-  h3 {
+  h2 {
     line-height: 14px;
     font-size: ${({ theme }) => theme.fontSize.small};
     color: ${({ theme }) => theme.colors.lightGray};
@@ -39,10 +27,16 @@ const StyledCampaignInput = styled.main`
     width: 322px;
     height: 204px;
     position: relative;
-    background-color: #f2f2f2;
+    background: #f2f2f2;
     border: 0.5 solid #dbdbdb;
     border-radius: 10px;
     cursor: pointer;
+  }
+
+  .campaign-img-label img {
+    width: 100%;
+    height: 100%;
+    border-radius: 10px;
   }
 
   .campaign-img-label::after {
@@ -61,6 +55,10 @@ const StyledCampaignInput = styled.main`
 
   input::placeholder {
     color: #dbdbdb;
+  }
+
+  .error-message {
+    color: ${({ theme }) => theme.colors.Orange};
   }
 `;
 


### PR DESCRIPTION
### 📝 Subject

캠페인 등록 기능 구현

### 💻 Description

업로드 한 이미지는 서버를 거쳐 오고,
각 입력 창들은 형식이 일치한 지 검사한 뒤
모든 값들이 유효하다면 저장 버튼이 활성화 됩니다.
저장 버튼을 누르면 각 값들이 서버로 전송하여 캠페인이 등록 됩니다.

### 💽 Commits

커밋 해시값을 적어주세요.

1. 7ad065f5b1f5551f855a1dcb99b50adfee69de8e : 캠페인 등록 기능 구현 close #60 
2. d281f9e98bf18c96f7a5fa2a70aeae26ecc5042f : TopUploadNav, Campaign의 styled 파일 수정
3. d529652595bca30e9594dfa704e1a7f189f6f3a2 : TopUploadNav 버튼에 onClick 추가
4. 68a8a64084cfb1e2fe6d9e04ea146415875d86e3 : ProfileInfo의 프로필 수정과 활동 등록 버튼에 페이지 연결 기능 추가

### 🖼 Result

![campaign](https://user-images.githubusercontent.com/112460306/209822618-3a21be8e-d377-4be0-ab38-25dafa1689a4.gif)
