### PR TITLE
Style/HomeFeed 페이지 스타일링 재정렬

### DIFF
--- a/src/components/Navbar/styled.jsx
+++ b/src/components/Navbar/styled.jsx
@@ -8,6 +8,7 @@ const StyledTopBasicNav = styled.nav`
   padding: 13px 16px;
   position: relative;
   border-bottom: 0.5px solid #dbdbdb;
+  align-items: center;
 
   div {
     width: 22px;
@@ -17,11 +18,11 @@ const StyledTopBasicNav = styled.nav`
   img {
     width: 22px;
     height: 22px;
-    vertical-align: middle;
     cursor: pointer;
   }
   span {
     font-size: ${({ theme }) => theme.fontSize.xlarge};
+    margin: 0px;
   }
   input {
     width: 316px;

--- a/src/components/TabMenu/styled.jsx
+++ b/src/components/TabMenu/styled.jsx
@@ -9,7 +9,7 @@ const StyledTabMenu = styled.article`
   display: flex;
   justify-content: space-evenly;
   align-items: center;
-  background-color: white;
+  /* background-color: white; */
   border-top: 0.5px solid #dbdbdb;
 `;
 

--- a/src/components/TextPost/TextPost.jsx
+++ b/src/components/TextPost/TextPost.jsx
@@ -27,8 +27,8 @@ const TextPost = ({ postData }) => {
         </UserPost>
         <StyledPostMessage>
           <StyledPostLink to={`/post/${postData.id}`}>
-            {postData.image && <img src={postData.image} alt="게시물 이미지" />}
             <p>{postData.content}</p>
+            {postData.image && <img src={postData.image} alt="게시물 이미지" />}
           </StyledPostLink>
           <LikeCommentButton postData={postData} />
           <span>{newDate}</span>

--- a/src/components/TextPost/TextPost.jsx
+++ b/src/components/TextPost/TextPost.jsx
@@ -1,9 +1,7 @@
 import React, { useCallback } from 'react';
-
+import { Link } from 'react-router-dom';
 import { StyledTextPost, StyledPostMessage, StyledPostLink } from './styled';
-
 import MoreVertical from '../../assets/icon/icon-more-vertical-small.svg';
-
 import UserInfo from '../UserInfo/UserInfo';
 import UserPost from '../UserPost/UserPost';
 import LikeCommentButton from '../LikeCommentButton/LikeCommentButton';
@@ -20,10 +18,14 @@ const TextPost = ({ postData }) => {
     <>
       <StyledTextPost>
         <UserPost>
-          <UserInfo user={postData.author} />
-          <button onClick={handlePostModal}>
-            <img src={MoreVertical} alt="더보기 이미지" />
-          </button>
+          <div className="upload-user-box">
+            <Link to="profile">
+              <UserInfo user={postData.author} />
+            </Link>
+            <button onClick={handlePostModal} className="moreBtn">
+              <img src={MoreVertical} alt="더보기 이미지" />
+            </button>
+          </div>
         </UserPost>
         <StyledPostMessage>
           <StyledPostLink to={`/post/${postData.id}`}>

--- a/src/components/TextPost/styled.jsx
+++ b/src/components/TextPost/styled.jsx
@@ -4,7 +4,11 @@ import styled from 'styled-components';
 export const StyledTextPost = styled.section`
   width: 358px;
   margin: 0 auto;
-
+  .upload-user-box {
+    position: relative;
+    display: flex;
+    right: 16px;
+  }
   span {
     font-size: ${({ theme }) => theme.fontSize.xsmall};
     color: ${({ theme }) => theme.colors.lightGray};
@@ -34,7 +38,7 @@ export const StyledPostLink = styled(Link)`
     object-fit: cover;
     text-align: center;
     border: 0.5px solid #dbdbdb;
-    border-radius: 4px;
+    border-radius: 10px;
 
     /* padding: 15px 0px;
     margin-left: -54px; */

--- a/src/components/TextPost/styled.jsx
+++ b/src/components/TextPost/styled.jsx
@@ -13,6 +13,7 @@ export const StyledTextPost = styled.section`
 
 export const StyledPostMessage = styled.section`
   padding-left: 54px;
+  margin-bottom: 20px;
 `;
 
 export const StyledPostLink = styled(Link)`
@@ -21,7 +22,7 @@ export const StyledPostLink = styled(Link)`
   width: 100%;
   margin-top: 16px;
   p {
-    margin-top: 16px;
+    margin: 16px 0px;
     font-size: ${({ theme }) => theme.fontSize.medium};
   }
   & > img {
@@ -34,6 +35,7 @@ export const StyledPostLink = styled(Link)`
     text-align: center;
     border: 0.5px solid #dbdbdb;
     border-radius: 4px;
+
     /* padding: 15px 0px;
     margin-left: -54px; */
   }
@@ -48,7 +50,7 @@ export const StyledHeartChat = styled.div`
 
   div {
     img {
-      vertical-align: middle;
+      /* vertical-align: top; */
       margin-right: 8px;
     }
     span {

--- a/src/components/UserInfo/UserInfo.jsx
+++ b/src/components/UserInfo/UserInfo.jsx
@@ -5,8 +5,14 @@ import StyledUserInfo from './styled';
 function UserInfo({ user }) {
   return (
     <StyledUserInfo>
-      <img className="basic-profile" src={user.image} alt="유저프로필이미지" />
-      <div>
+      <div className="profile-box">
+        <img
+          className="basic-profile"
+          src={user.image}
+          alt="유저프로필이미지"
+        />
+      </div>
+      <div className="user-name">
         <h3>{user.username}</h3>
         <span>{user.accountname}</span>
       </div>

--- a/src/components/UserInfo/styled.jsx
+++ b/src/components/UserInfo/styled.jsx
@@ -7,20 +7,28 @@ const StyledUserInfo = styled.article`
   gap: 12px;
   width: 358px;
 
-  .basic-profile {
+  .profile-box {
     width: 42px;
     height: 42px;
+    border-radius: 70%;
+    overflow: hidden;
+    border: 1px solid #dbdbdb;
+  }
+  .basic-profile {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 
-  div {
-    margin-top: 10px;
+  .user-name {
+    margin-top: 4px;
   }
 
   span {
     display: block;
     font-size: ${({ theme }) => theme.fontSize.small};
     color: ${({ theme }) => theme.colors.lightGray};
-    margin-top: 6px;
+    margin-top: 2px;
   }
 `;
 

--- a/src/components/UserInfo/styled.jsx
+++ b/src/components/UserInfo/styled.jsx
@@ -6,6 +6,7 @@ const StyledUserInfo = styled.article`
   font-size: ${({ theme }) => theme.fontSize.medium};
   gap: 12px;
   width: 358px;
+  height: 42px;
 
   .profile-box {
     width: 42px;
@@ -21,7 +22,7 @@ const StyledUserInfo = styled.article`
   }
 
   .user-name {
-    margin-top: 4px;
+    padding-top: 7px;
   }
 
   span {

--- a/src/pages/HomeFeed/HomeFeedPage.jsx
+++ b/src/pages/HomeFeed/HomeFeedPage.jsx
@@ -44,7 +44,7 @@ function HomeFeedPage() {
           ))}
         </main>
       ) : (
-        <main>
+        <main className='non-post'>
           <img src={LogoGray} alt="회색이미지" />
           <span>유저를 검색해 팔로우 해보세요!</span>
           <Button size="md" onClick={goSearch}>

--- a/src/pages/HomeFeed/styled.jsx
+++ b/src/pages/HomeFeed/styled.jsx
@@ -6,7 +6,6 @@ const StyledHomeFeedPage = styled.div`
   border: 0.5px solid #dbdbdb;
   display: flex;
   flex-direction: column;
-  height: 826px;
 
   main {
     width: 390px;

--- a/src/pages/HomeFeed/styled.jsx
+++ b/src/pages/HomeFeed/styled.jsx
@@ -11,7 +11,6 @@ const StyledHomeFeedPage = styled.div`
   main {
     width: 390px;
     height: 712px;
-
     padding: 20px 16px;
     display: flex;
     flex-direction: column;
@@ -21,9 +20,11 @@ const StyledHomeFeedPage = styled.div`
       display: none;
     }
   }
-
+  .non-post {
+    padding-top: 220px;
+  }
   span {
-    display: block;
+    /* display: block; */
     margin: 20px 0px;
     font-size: ${({ theme }) => theme.fontSize.medium};
     color: #767676;


### PR DESCRIPTION
### 📝 Subject

- HomeFeed 페이지 내 발생한 스타일 오류 전체적 수정

### 💻 Description

- 기능 설명: HomeFeed 내에서 나타나는 스타일 오류 및 기능 일부분을 수정하였다.

### 💽 Commits

커밋 해시값을 적어주세요.
close #87 
1. 9e44ac4 : 상단의 '초록초록 피드' (가제) value 값의  위치를 수정
2. bdd2e63: 프로필의 이미지를 원형으로 통일
3. bfa2855 :  페이지 내  연속된 TextPost의  간격 수정   
4. cee06fb :  유저 검색 버튼의 가운데 정렬 
5. f86ef35: UserInfo의 accoutname과 username 간의 간격 수정

### 🖼 Result
![image](https://user-images.githubusercontent.com/62597615/210045143-0e30b2cf-e275-431d-a264-5668268c7e65.png)
![image](https://user-images.githubusercontent.com/62597615/210045286-210e5b97-3918-482e-b631-91b58b7667d3.png)


