### PR TITLE
Feat/PostUpload 기능 및 스타일 구현

### DIFF
--- a/src/pages/Post/PostUploadPage.jsx
+++ b/src/pages/Post/PostUploadPage.jsx
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TopUploadNav } from '../../components/Navbar/TopNavbar';
 import useAuthContext from '../../hooks/useAuthContext';
-import { StyledPostUploadPage, StyledUploadContents } from './styled';
-import iconbasicprofilesmall from '../../assets/icon/icon-basic-profile-small.svg';
+import {
+  StyledPostUploadPage,
+  StyledUploadContents,
+  StyledUploadImg,
+} from './styled';
 
 const BASEURL = 'https://mandarin.api.weniv.co.kr';
 
@@ -11,18 +14,31 @@ function PostUploadPage() {
   const [postContent, setPostContent] = useState('');
   const [postImg, setPostImg] = useState(null);
 
-  const [isValidPostImg, setIsValidPostImg] = useState(false);
+  // onSubmit 전에 passed 체크 (빈 게시물이면 전송불가)
   const [isValidPostContent, setIsValidPostContent] = useState(false);
+  const [isValidPostImg, setIsValidPostImg] = useState(false);
 
-  // const [checkPostImg, setCheckPostImg] = useState('');
-  // const [checkPostContent, setCheckPostContent] = useState('');
+  // 유효성검사 (content: 1자 이상, img: 유효한 확장자만 허용)
+  const [checkPostContent, setCheckPostContent] = useState(0);
+  const [checkPostImg, setCheckPostImg] = useState(false);
 
   const navigate = useNavigate();
+  const countRef = useRef();
   const { auth } = useAuthContext();
-  const passed = isValidPostImg && isValidPostContent;
+  const passed =
+    (isValidPostContent && checkPostContent) ||
+    (isValidPostImg && checkPostImg);
+  const contentMaxLength = 330;
 
   const handleContentChange = (e) => {
     setPostContent(e.target.value);
+  };
+
+  const CheckLength = (e) => {
+    const txtLength = e.target.value.replace(/<br\s*\/?>/gm, '\n').length;
+
+    setIsValidPostContent(txtLength);
+    setCheckPostContent(txtLength);
   };
 
   const handleImgChange = (e) => {
@@ -32,22 +48,30 @@ function PostUploadPage() {
 
     formData.append('image', imgFile);
 
+    // 이미지 filename 응답 API(1개)
     const imgUpload = async () => {
-      // 이미지 filename 응답 API(1개)
       const ImgFetchResult = await fetch(`${BASEURL}/image/uploadfile`, {
         method: 'POST',
         // headers: {
-        //   Authorization: `Bearer ${auth.token}`,
         //   'Content-type': 'multipart/form-data',
         // },
         body: formData,
       });
-      const res = await ImgFetchResult.json();
+      const result = await ImgFetchResult.json();
 
-      // 이부분부터 3줄 이해안감
-      setPostImg(`${BASEURL}/${res.filename}`);
+      if (!result.filename) {
+        setPostImg(null);
+        setCheckPostImg(false);
+
+        alert(result.message);
+        return;
+      }
+
+      setPostImg(`${BASEURL}/${result.filename}`);
     };
 
+    setIsValidPostImg(true);
+    setCheckPostImg(true);
     imgUpload();
     setPostImg(imgFile);
   };
@@ -72,19 +96,12 @@ function PostUploadPage() {
 
     const result = await PostUpload.json();
 
-    // console.log(result);
     navigate(`/post/${result.post.id}`);
   };
 
-  // console.log(auth);
-
   return (
     <StyledPostUploadPage>
-      <TopUploadNav
-        // disabled={!passed}
-        onClick={onSubmit}
-        value="업로드"
-      />
+      <TopUploadNav disabled={!passed} onClick={onSubmit} value="업로드" />
       <StyledUploadContents>
         <h2 className="ir">게시글 작성</h2>
         <img src={auth.image} alt="" />
@@ -93,25 +110,44 @@ function PostUploadPage() {
           <form className="post-write-form">
             <textarea
               name="text"
-              placeholder="게시글 입력하기..."
+              placeholder="330자 이상 입력하실 수 없습니다."
               value={postContent}
               onChange={handleContentChange}
+              maxLength={contentMaxLength}
+              onKeyUp={CheckLength}
               required
             ></textarea>
             <label htmlFor="imgupload" className="campaign-img-label"></label>
             <input
+              className="ir"
               type="file"
               id="imgupload"
               accept="image/*"
               onChange={handleImgChange}
             />
           </form>
+          <span ref={countRef}>현재 {checkPostContent}자 작성</span>
         </article>
-        {/* 추가한 이미지 프리뷰 구현 */}
-        <h4 className="ir">추가한 이미지</h4>
-        {/* <ul>
-          <li><img src="" alt="" /></li>
-        </ul> */}
+        {postImg ? (
+          <StyledUploadImg>
+            <h4 className="ir">추가한 이미지</h4>
+            <ul>
+              <li>
+                <img
+                  src={postImg}
+                  alt="추가한 이미지"
+                  onClick={() => {
+                    setPostImg(null);
+                    setIsValidPostImg(false);
+                    setCheckPostImg(false);
+                  }}
+                />
+              </li>
+            </ul>
+          </StyledUploadImg>
+        ) : (
+          <></>
+        )}
       </StyledUploadContents>
     </StyledPostUploadPage>
   );

--- a/src/pages/Post/PostUploadPage.jsx
+++ b/src/pages/Post/PostUploadPage.jsx
@@ -1,25 +1,113 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { TopUploadNav } from '../../components/Navbar/TopNavbar';
-import iconbasicprofilesmall from '../../assets/icon/icon-basic-profile-small.svg';
+import useAuthContext from '../../hooks/useAuthContext';
 import { StyledPostUploadPage, StyledUploadContents } from './styled';
+import iconbasicprofilesmall from '../../assets/icon/icon-basic-profile-small.svg';
+
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
 
 function PostUploadPage() {
+  const [postContent, setPostContent] = useState('');
+  const [postImg, setPostImg] = useState(null);
+
+  const [isValidPostImg, setIsValidPostImg] = useState(false);
+  const [isValidPostContent, setIsValidPostContent] = useState(false);
+
+  // const [checkPostImg, setCheckPostImg] = useState('');
+  // const [checkPostContent, setCheckPostContent] = useState('');
+
+  const navigate = useNavigate();
+  const { auth } = useAuthContext();
+  const passed = isValidPostImg && isValidPostContent;
+
+  const handleContentChange = (e) => {
+    setPostContent(e.target.value);
+  };
+
+  const handleImgChange = (e) => {
+    // setPostImg(e.target.files[0]);
+    const imgFile = e.target.files[0];
+    const formData = new FormData();
+
+    formData.append('image', imgFile);
+
+    const imgUpload = async () => {
+      // 이미지 filename 응답 API(1개)
+      const ImgFetchResult = await fetch(`${BASEURL}/image/uploadfile`, {
+        method: 'POST',
+        // headers: {
+        //   Authorization: `Bearer ${auth.token}`,
+        //   'Content-type': 'multipart/form-data',
+        // },
+        body: formData,
+      });
+      const res = await ImgFetchResult.json();
+
+      // 이부분부터 3줄 이해안감
+      setPostImg(`${BASEURL}/${res.filename}`);
+    };
+
+    imgUpload();
+    setPostImg(imgFile);
+  };
+
+  // 전체 업로드 버튼
+  const onSubmit = async () => {
+    const postData = {
+      post: {
+        content: postContent,
+        image: postImg,
+      },
+    };
+
+    const PostUpload = await fetch(`${BASEURL}/post`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(postData),
+    });
+
+    const result = await PostUpload.json();
+
+    // console.log(result);
+    navigate(`/post/${result.post.id}`);
+  };
+
+  // console.log(auth);
+
   return (
     <StyledPostUploadPage>
-      <TopUploadNav value="업로드" />
-      {/* button disabled 처리 (선영님 코드 참고) */}
+      <TopUploadNav
+        // disabled={!passed}
+        onClick={onSubmit}
+        value="업로드"
+      />
       <StyledUploadContents>
         <h2 className="ir">게시글 작성</h2>
-        <img src={iconbasicprofilesmall} alt="" />
+        <img src={auth.image} alt="" />
         <article className="post-write">
-          <h3 className="ir">글 입력 칸</h3>
+          <h3 className="ir">글 입력 공간</h3>
           <form className="post-write-form">
-            <textarea name="text" placeholder="게시글 입력하기..."></textarea>
+            <textarea
+              name="text"
+              placeholder="게시글 입력하기..."
+              value={postContent}
+              onChange={handleContentChange}
+              required
+            ></textarea>
             <label htmlFor="imgupload" className="campaign-img-label"></label>
-            <input type="file" id="imgupload" />
+            <input
+              type="file"
+              id="imgupload"
+              accept="image/*"
+              onChange={handleImgChange}
+            />
           </form>
         </article>
-
+        {/* 추가한 이미지 프리뷰 구현 */}
         <h4 className="ir">추가한 이미지</h4>
         {/* <ul>
           <li><img src="" alt="" /></li>

--- a/src/pages/Post/styled.jsx
+++ b/src/pages/Post/styled.jsx
@@ -12,15 +12,8 @@ export const StyledUploadContents = styled.main`
   padding: 20px 16px;
   display: flex;
   height: 796px;
+  position: relative;
 
-  input,
-  .ir {
-    display: block;
-    overflow: hidden;
-    font-size: 1px;
-    line-height: 0;
-    text-indent: -9999px;
-  }
   img {
     width: 42px;
     height: 42px;
@@ -40,6 +33,12 @@ export const StyledUploadContents = styled.main`
 
   article {
     position: relative;
+
+    span {
+      float: right;
+      margin-right: 20px;
+      color: ${({ theme }) => theme.colors.Green};
+    }
   }
 
   .campaign-img-label {
@@ -50,5 +49,29 @@ export const StyledUploadContents = styled.main`
     height: 50px;
     background-image: url(${iconimgbuttongreen});
     cursor: pointer;
+  }
+`;
+
+export const StyledUploadImg = styled.div`
+  position: absolute;
+  bottom: 410px;
+  left: 63px;
+  cursor: pointer;
+
+  ul > li {
+    width: 140px;
+    height: 90px;
+    border: 0.5px solid #dbdbdb;
+    border-radius: 8px;
+
+    img {
+      width: 100%;
+      height: 100%;
+      font-size: ${({ theme }) => theme.fontSize.xlarge};
+      font-weight: 700;
+      object-fit: cover;
+      text-align: center;
+      border-radius: 8px;
+    }
   }
 `;


### PR DESCRIPTION
### 📝 Subject
게시글 작성 기능 및 스타일 구현

### 💻 Description

- 명세 요구사항: 
하단 tabMenu에서 "게시글 작성"을 클릭하면 업로드 페이지로 이동.
글 또는 사진이 업로드되면 업로드 버튼이 활성화되며, 버튼을 누르면 게시글이 업로드됩니다. 
사진은 우측 하단 버튼을 클릭하여 업로드할 수 있습니다. 

- 기능 설명:  
**게시물 업로드:**  
현재 1장의 사진만 업로드 가능하도록 구현되었습니다. 
**유효성 검사:**  
게시글 또는 사진 중 하나라도 유효한 값이 있어야 업로드됩니다. 
게시글은 1글자 이상~330글자 이하 값이 유효하며, 
게시글 내용이 없을 경우 이미지가 들어 있어야 유효 처리되며 업로드 가능합니다. 
이미지를 업로드할 때 이미지 파일이 아닌 경우 alert창으로 "이미지 파일만 업로드 가능하다"는 메시지를 띄워줍니다. 
**사용자 UI 개선:**  
게시글을 작성하기 전, 330자까지만 입력 가능하다는 placeholder를 띄워줍니다.
이후 maxLength로 330자를 제한하며, 330자에 도달한 경우 더 이상 입력되지 않습니다.
textarea 우측 하단에 사용자가 현재 몇 자를 입력했는지 표시됩니다. 

### 💽 Commits
close #90 
1. 3f9beab90db00eaa11ede6d1d20e4daa054bf523: 게시물 업로드 기능 구현
2. e2156038e037b68013f496e19fc92102e9acab2f: 유효성 검사 추가
3. 6dce3afe87ca4703c29691312ac89254aac249f6: 추가한 이미지 프리뷰 및 글자수 보여주기 스타일링

### 🖼 Result
![image](https://user-images.githubusercontent.com/85055608/210048815-1e74ff01-74d1-4130-b36c-6fad26226998.png)
![image](https://user-images.githubusercontent.com/85055608/210048911-5010f931-5109-4264-9b10-81a15cfba3e5.png)

