### PR TITLE
Feat/FollowersPage컴포넌트생성 및 기능추가

### DIFF
--- a/src/components/Profile/ProfileInfo.jsx
+++ b/src/components/Profile/ProfileInfo.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Button from '../../components/Button/Button';
 import { TopBasicNav } from '../../components/Navbar/TopNavbar';
 import Share from '../../assets/icon/icon-share.svg';
@@ -9,7 +9,7 @@ import useAuthContext from '../../hooks/useAuthContext';
 
 function ProfileInfo({ accountName }) {
   const { auth } = useAuthContext();
-
+  const navigate = useNavigate();
   const [userInfo, setUserInfo] = useState({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -48,7 +48,17 @@ function ProfileInfo({ accountName }) {
 
       <div className="ProfileHeader">
         <p className="followers">
-          {userInfo.followerCount}
+          <button
+            onClick={() => {
+              navigate('./followers/', {
+                state: {
+                  accountName,
+                },
+              });
+            }}
+          >
+            {userInfo.followerCount}
+          </button>
           <span>followers</span>
         </p>
         <img src={userInfo.image} alt="프로필 사진" />

--- a/src/pages/Follow/FollowItem.jsx
+++ b/src/pages/Follow/FollowItem.jsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useState } from 'react';
+
+import UserInfo from '../../components/UserInfo/UserInfo';
+import Button from '../../components/Button/Button';
+import useAuthContext from '../../hooks/useAuthContext';
+
+function FollowItem({ user }) {
+  const { auth } = useAuthContext();
+  const [isFollow, setIsFollow] = useState(user.isfollow);
+
+  console.log(isFollow);
+
+  const followAPI = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `https://mandarin.api.weniv.co.kr/profile/${user.accountname}/follow`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${auth.token}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+      const result = await res.json();
+
+      setIsFollow((isfollow) => !isfollow);
+      return result;
+    } catch (error) {
+      return new Error(error);
+    }
+  }, [auth.token, user.accountname]);
+
+  const unFollowAPI = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `https://mandarin.api.weniv.co.kr/profile/${user.accountname}/unfollow`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${auth.token}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+      const result = await res.json();
+
+      setIsFollow((isfollow) => !isfollow);
+      return result;
+    } catch (error) {
+      return new Error(error);
+    }
+  }, [auth.token, user.accountname]);
+
+  const handleFollowState = () => {
+    if (isFollow) {
+      unFollowAPI();
+    } else {
+      followAPI();
+    }
+  };
+
+  return (
+    <li>
+      <UserInfo user={user} />
+      <Button size="xsm" onClick={handleFollowState} active={isFollow}>
+        {isFollow ? '취소' : '팔로우'}
+      </Button>
+    </li>
+  );
+}
+
+export default FollowItem;

--- a/src/pages/Follow/FollowersPage.jsx
+++ b/src/pages/Follow/FollowersPage.jsx
@@ -1,53 +1,76 @@
-import React from 'react';
-import Button from '../../components/Button/Button';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { TopBasicNav } from '../../components/Navbar/TopNavbar';
 import TabMenu from '../../components/TabMenu/TabMenu';
-import UserInfo from '../../components/UserInfo/UserInfo';
+
+import useAuthContext from '../../hooks/useAuthContext';
+import FollowItem from './FollowItem';
 import {
-  FollowerList,
-  FollowerWrap,
-  FollowerTit,
-  List,
+  StyledFollowersListWrapper,
+  StyledFollowersWrapper,
+  StyledFollowersList,
   TabMenuWrap,
 } from './styled';
 
-const FollowersPage = () => (
-  <FollowerWrap>
-    <FollowerTit>Follower</FollowerTit>
-    <TopBasicNav value="Followers" />
-    <FollowerList>
-      <List>
-        <li className="Follow">
-          <UserInfo />
-          <Button size="xsm" status="disabled">
-            팔로우
-          </Button>
-        </li>
-        <li className="Cancel">
-          <UserInfo />
-          <Button size="xsm" status="disabled">
-            취소
-          </Button>
-        </li>
-        <li className="Cancel">
-          <UserInfo />
-          <Button size="xsm" status="disabled">
-            취소
-          </Button>
-        </li>
-        <li className="Follow">
-          <UserInfo />
-          <Button size="xsm" status="disabled">
-            팔로우
-          </Button>
-        </li>
-      </List>
-    </FollowerList>
+const FollowersPage = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [followers, setFollowers] = useState(null);
 
-    <TabMenuWrap>
-      <TabMenu />
-    </TabMenuWrap>
-  </FollowerWrap>
-);
+  const location = useLocation();
+  const { auth } = useAuthContext();
+  const accountName = location.state.accountName;
+
+  useEffect(() => {
+    setLoading(true);
+
+    fetch(`https://mandarin.api.weniv.co.kr/profile/${accountName}/follower`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-Type': 'application/json',
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        setFollowers(res);
+        setLoading(false);
+      })
+      .catch((e) => {
+        setError(e);
+      });
+  }, [auth.token, accountName]);
+
+  if (loading) {
+    return <div>Loading중입니다...</div>;
+  }
+
+  if (error) {
+    return <div>Error메세지: {error}</div>;
+  }
+
+  return (
+    <StyledFollowersWrapper>
+      <h2 className="ir">Follower</h2>
+      <TopBasicNav value="Followers" />
+
+      <StyledFollowersListWrapper>
+        <StyledFollowersList>
+          {!followers || followers.length === 0 ? (
+            <li>팔로우 목록이 존재하지 않습니다.</li>
+          ) : (
+            followers.map((follower) => (
+              <FollowItem user={follower} key={follower._id} />
+            ))
+          )}
+        </StyledFollowersList>
+      </StyledFollowersListWrapper>
+
+      <TabMenuWrap>
+        <TabMenu />
+      </TabMenuWrap>
+    </StyledFollowersWrapper>
+  );
+};
 
 export default FollowersPage;

--- a/src/pages/Follow/styled.jsx
+++ b/src/pages/Follow/styled.jsx
@@ -1,21 +1,12 @@
 import styled from 'styled-components';
 
-const FollowerWrap = styled.section`
+const StyledFollowersWrapper = styled.section`
   position: relative;
   width: 390px;
   height: 820px;
 `;
 
-const FollowerTit = styled.h2`
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-`;
-
-const FollowerList = styled.div`
+const StyledFollowersListWrapper = styled.div`
   padding: 24px 0;
   overflow: scroll;
   ::-webkit-scrollbar {
@@ -24,7 +15,7 @@ const FollowerList = styled.div`
   height: 712px;
 `;
 
-const List = styled.ul`
+const StyledFollowersList = styled.ul`
   margin: 0 16px;
   display: flex;
   flex-direction: column;
@@ -38,11 +29,9 @@ const List = styled.ul`
     justify-content: space-between;
 
     Button {
-      background-color: ${({ theme }) => theme.colors.Green};
-      color: white;
       position: absolute;
       right: 0px;
-      margin: 11px 0px;
+      margin: 4px 0px;
       height: 28px;
     }
   }
@@ -52,4 +41,9 @@ const TabMenuWrap = styled.div`
   bottom: 0px;
 `;
 
-export { FollowerWrap, FollowerTit, FollowerList, List, TabMenuWrap };
+export {
+  StyledFollowersWrapper,
+  StyledFollowersListWrapper,
+  StyledFollowersList,
+  TabMenuWrap,
+};

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Outlet, Route, Routes } from 'react-router-dom';
 
 import StartSplash from './../pages/Splash/StartSplash';
 import LoginPage from '../pages/Login/LoginPage';
@@ -29,8 +29,10 @@ function Router() {
       <Route path="/postupload" element={<PostUploadPage />}></Route>
       <Route path="/chatlist" element={<ChatListPage />}></Route>
       <Route path="/chatroom" element={<ChatRoomPage />}></Route>
-      <Route path="/profile/:userId" element={<ProfilePage />}></Route>
-      <Route path="/followers" element={<FollowersPage />}></Route>
+      <Route path="/profile/:userId/" element={<Outlet />}>
+        <Route path="" element={<ProfilePage />} />
+        <Route path="followers/" element={<FollowersPage />} />
+      </Route>
       <Route path="/search" element={<SearchPage />}></Route>
       <Route path="*" element={<NotFoundPage />}></Route>
     </Routes>


### PR DESCRIPTION
### 📝 Subject

FollowersPage컴포넌트생성 및 기능추가

### 💻 Description

- 명세 요구사항: FollowersPage컴포넌트생성 및 기능추가
- 기능 설명
1. FollowersPage로 넘어가기 위해 Router경로 설정 및 ProfileInfo 컴포넌트에서 경로 이동 추가
2. FollowersPage로 이동 후 API통신을 통해 팔로워가 없는 경우와 팔로워 있는 경우 별도의 UI를 보여주도록 설정
3. FollowItem컴포넌트로 따로 분리 후 팔로우 언팔로우 기능 추가 및 스타일 추가

### 💽 Commits

1. 95b8cd8: ProfilePage에서 FollowersPage로 이동하는 라우터 경로 설정 중첩라우터로 처리
2. f9b62af: ProfileInfo컴포넌트에서 FollowersPage로 useNavigate를 통해 경로 이동 및 데이터 전송
3. 1a35f04: FollowerPage에서 API통신을 통한 데이터 렌더링
4. 9cabffd: FollowItem컴포넌트를 별도 생성 후 언팔로우 , 팔로우 기능 추가 및 스타일 추가 close #95 

### 🖼 Result

1. 내가 팔로우 하지 않는 경우
<img width="358" alt="image" src="https://user-images.githubusercontent.com/92032081/210128139-d5012738-5981-47e1-bef2-e9db8a19d548.png">

2. 내가 팔로우한 경우
<img width="362" alt="image" src="https://user-images.githubusercontent.com/92032081/210128156-868535d4-6f03-4897-a029-219b225b4269.png">

3. 팔로워 목록 보여주기
<img width="369" alt="image" src="https://user-images.githubusercontent.com/92032081/210128165-a1df4f8e-2fa4-4f4c-b578-d15f22f513f5.png">

4. 팔로워가 없는 경우
해당 부분은 스타일 추가가 필요한 부분입니다.
<img width="393" alt="image" src="https://user-images.githubusercontent.com/92032081/210128203-cfdb66e9-4446-4fea-bb31-ea7c007c3114.png">
