### PR TITLE
Fix/페이지경로 및 스타일수정

### DIFF
--- a/src/components/AlbumPost/styled.jsx
+++ b/src/components/AlbumPost/styled.jsx
@@ -1,13 +1,18 @@
 import styled from 'styled-components';
 
 const StyledAlbumCard = styled.article`
-  width: 114px;
-  height: 114px;
-  border: 1px solid ${({ theme }) => theme.colors.lightGray};
-  border-radius: 4px;
-  overflow: hidden;
+  > a {
+    display: block;
+    width: 114px;
+    height: 114px;
+    border: 1px solid ${({ theme }) => theme.colors.ActiveborderColor};
+    overflow: hidden;
+    border-radius: 4px;
+  }
+
   img {
     width: 100%;
+    height: 100%;
   }
 `;
 

--- a/src/components/CampaignCard/CampaignCard.jsx
+++ b/src/components/CampaignCard/CampaignCard.jsx
@@ -4,10 +4,12 @@ import CampaignCardWrapper from './styled';
 
 const CampaginCard = ({ campaign }) => (
   <CampaignCardWrapper>
-    <img src={campaign.itemImage} alt={campaign.itemName} />
+    <a href={campaign.link}>
+      <img src={campaign.itemImage} alt={campaign.itemName} />
+    </a>
     <p>{campaign.itemName}</p>
     <p>
-      <span>현재 진행 중</span>
+      <span>{`참가인원 ${campaign.price}명`}</span>
     </p>
   </CampaignCardWrapper>
 );

--- a/src/components/CampaignCard/styled.jsx
+++ b/src/components/CampaignCard/styled.jsx
@@ -1,12 +1,18 @@
 import styled from 'styled-components';
 
 const CampaignCardWrapper = styled.li`
-  position: relative;
   cursor: pointer;
   width: 140px;
   list-style: none;
+  flex-shrink: 0;
+
+  a {
+    display: block;
+    width: 100%;
+  }
 
   img {
+    width: 100%;
     height: 90px;
     border: 0.5px solid #bdbdbd;
     border-radius: 8px;

--- a/src/components/LikeCommentButton/LikeCommentButton.jsx
+++ b/src/components/LikeCommentButton/LikeCommentButton.jsx
@@ -56,7 +56,7 @@ function LikeCommentButton({ postData }) {
   }, [auth.token, postData.id]);
 
   const handleClickCount = useCallback(
-    async (e) => {
+    (e) => {
       if (e.currentTarget.name === 'like') {
         if (!isLike) {
           LikeAPI();

--- a/src/components/UserList/UserList.jsx
+++ b/src/components/UserList/UserList.jsx
@@ -10,11 +10,11 @@ function UserList({
   username,
   accountname,
 }) {
-  // const itemId = searchList.accountname.slice(2);
+  const newaccountname = accountname.slice(2);
 
   return (
     <StyledUserList>
-      <Link to={`/myprofile`}>
+      <Link to={`/profile/${newaccountname}`}>
         <li className="userList" key={userkey}>
           <img src={image} alt="" />
           <div className="userInfo">

--- a/src/pages/CampaignUpload/CampaignUploadPage.jsx
+++ b/src/pages/CampaignUpload/CampaignUploadPage.jsx
@@ -130,7 +130,7 @@ export default function CampaignPage() {
       body: JSON.stringify(userData),
     });
 
-    navigate(`/myprofile`);
+    navigate(`/profile/${auth.accountName}`);
 
     const result = campaignUpload.json();
 

--- a/src/pages/Post/PostPage.jsx
+++ b/src/pages/Post/PostPage.jsx
@@ -10,10 +10,8 @@ import useAuthContext from '../../hooks/useAuthContext';
 export default function PostPage() {
   const { postId } = useParams();
   const { auth } = useAuthContext();
-  const [postData, setPostData] = useState([]);
+  const [postData, setPostData] = useState(null);
   const [loading, setLoading] = useState(false);
-
-  console.log(postData);
 
   useEffect(() => {
     setLoading(true);
@@ -26,7 +24,7 @@ export default function PostPage() {
     })
       .then((res) => res.json())
       .then((res) => {
-        setPostData([res.post]);
+        setPostData(res.post);
         setLoading(false);
       })
       .catch((e) => new Error(e));
@@ -39,9 +37,9 @@ export default function PostPage() {
   return (
     <StyledWrapper>
       <TopBasicNav />
-      {postData.map((post) => (
-        <TextPost key={post.id} postData={post}></TextPost>
-      ))}
+      {postData ? (
+        <TextPost key={postData._id} postData={postData}></TextPost>
+      ) : null}
       <CommentList />
       <CommentInput />
     </StyledWrapper>


### PR DESCRIPTION
### 📝 Subject

페이지경로 및 스타일수정

### 💻 Description

- 명세 요구사항: 페이지경로 및 스타일수정
- 기능 설명
1. UserList컴포넌트에서 해당 ProfilePage로 이동하기 위한 경로 수정
2. CampaignUploadPage에서 업로드 후 페이지 자동으로 해당 로그인 된 유저의 프로필 페이지로 이동 경로 수정
3. CampaignCard 데이터 렌더링 수정 
4. PostPage 데이터 렌더링 코드 수정 및 AlbumPost 컴포넌트 스타일 수정
5. LikeCommentButton컴포넌트 불요한 코드 삭제

### 💽 Commits

1. 4e1f8ed: UserList컴포넌트에서 해당 ProfilePage로 이동하기 위한 경로 수정 close #97 
2. 46b3d63: CampaignUploadPage에서 업로드 후 페이지 자동으로 해당 로그인 된 유저의 프로필 페이지로 이동 경로 수정, CampaignCard 데이터 렌더링 수정 
3. 7f36b57: PostPage 데이터 렌더링 코드 수정 및 AlbumPost 컴포넌트 스타일 수정
4. 7534cbb: LikeCommentButton컴포넌트 불요한 코드 삭제 

### 🖼 Result
1. AlbumPost컴포넌트 스타일 수정
<img width="406" alt="image" src="https://user-images.githubusercontent.com/92032081/210128697-576af939-9afb-4581-b04c-a3dc9f023aae.png">

2. CampaignCard 데이터 렌더링 수정 된 모습
<img width="150" alt="image" src="https://user-images.githubusercontent.com/92032081/210128713-55561c0e-9fa7-4587-9a36-3f699b1b90df.png">


