### PR TITLE
Style/ Search 페이지 리스트 출력 수정 및 Navbar Input 수정

### DIFF
--- a/src/components/Navbar/styled.jsx
+++ b/src/components/Navbar/styled.jsx
@@ -25,15 +25,16 @@ const StyledTopBasicNav = styled.nav`
     margin: 0px;
   }
   input {
+    display: block;
     width: 316px;
     height: 32px;
-    padding: 9px 16px;
+    margin: 8px 0px;
+    padding: 0px 16px;
     background-color: #f2f2f2;
     border: none;
     border-radius: 32px;
-    position: absolute;
-    left: 60px;
-    bottom: 8px;
+    background-color: ${({ theme }) => theme.colors.lightGreen};
+    font-size: ${({ theme }) => theme.fontSize.medium};
   }
   button {
     color: white;

--- a/src/pages/Search/styled.jsx
+++ b/src/pages/Search/styled.jsx
@@ -3,14 +3,14 @@ import styled from 'styled-components';
 const StyledSearch = styled.section`
   width: 390px;
   height: 820px;
-  border: 1px solid black;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  position: relative;
   border: 1px solid black;
   .searchMain {
+    display: flex;
+    flex-direction: column;
     height: 712px;
-    padding: 20px 16px 0;
+    gap: 16px;
+    padding: 20px 16px;
     overflow: scroll;
     ::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
### 📝 Subject

- Search 페이지 리스트 출력 수정 및 Navbar Input 수정

### 💻 Description

기능 설명: 
- Navbar의 Search Input 부분 색상 및 위치를 수정하였습니다.
- Search부분의 리스트 출력 오류를 수정하고 하단 tabMenu와의 겹침 현상 제거하였습니다.

### 💽 Commits
close #100 
1. 130b4e9 : searchbar 의 input 스타일링
2. ff7167f : search 페이지의 하단 tabMenu 겹침현상 제거 및 리스트 출력 위치 수정

### 🖼 Result

![image](https://user-images.githubusercontent.com/62597615/210130635-6c7a739a-20da-49d1-8960-83711b9d63a5.png)
