### PR TITLE
style: Splash, IntoLoginPage 로고 수정

### DIFF
--- a/src/pages/IntroLogin/IntroLoginPage.jsx
+++ b/src/pages/IntroLogin/IntroLoginPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import FullLogoShadow from '../../assets/image/full-logo-shadow.svg';
+import fullLogo from '../../assets/image/full-logo.svg';
 import StyledIntroLoginPage from './styled';
 
 function IntroLoginPage() {
@@ -8,7 +8,7 @@ function IntroLoginPage() {
     <StyledIntroLoginPage>
       <div>
         <h1>
-          <img src={FullLogoShadow} alt="" />
+          <img src={fullLogo} alt="" />
         </h1>
         <section className="login-join-section">
           <ul className="sns-login">

--- a/src/pages/IntroLogin/styled.jsx
+++ b/src/pages/IntroLogin/styled.jsx
@@ -10,6 +10,7 @@ const StyledIntroLoginPage = styled.main`
   position: relative;
 
   h1 img {
+    filter: drop-shadow(2px 2px 4px #5f5f5fbe);
     position: absolute;
     margin: auto;
     top: 180px;

--- a/src/pages/Splash/SplashPage.jsx
+++ b/src/pages/Splash/SplashPage.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import fullLogo from '../../assets/image/full-logo-shadow.svg';
+import fullLogo from '../../assets/image/full-logo.svg';
 import StyledSplashPage from './styled';
 
 const SplashPage = () => (
   <StyledSplashPage>
     <h1 className="main-logo">
-      <img src={fullLogo} alt="fullLogoShadow" />
-      초록초록 예쁜 지구
+      <img src={fullLogo} alt="fullLogo" />
+      버드나다
     </h1>
   </StyledSplashPage>
 );

--- a/src/pages/Splash/styled.jsx
+++ b/src/pages/Splash/styled.jsx
@@ -15,11 +15,13 @@ const StyledSplashPage = styled.main`
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 10px;
   }
   .main-logo img {
     margin-top: 254px;
     width: 144px;
     height: 144px;
+    filter: drop-shadow(2px 2px 4px #5f5f5fbe);
   }
   .main-logo,
   .main-logo img {


### PR DESCRIPTION
### 📝 Subject

style: Splash, IntoLoginPage 로고 수정

### 💻 Description

- 기존 그림자 로고를 제거하고 기본 full-logo를 사용.
  fliter 속성을 이용하여 그림자를 만들어 공백을 제거.
- 사이트 이름 수정

### 💽 Commits

커밋 해시값을 적어주세요.

1. 5f4ecd3bd715013a28d11009cb61b72b49efd7f2 : close #104 

### 🖼 Result

![녹화_2023_01_01_17_39_10_761](https://user-images.githubusercontent.com/112460306/210165367-91a7cb79-c819-4b2b-a096-3d451d9d14c6.gif)
