### PR TITLE
Fix/스타일수정 및 라우터, 경로 설정

### DIFF
--- a/src/components/Comment/CommentList.jsx
+++ b/src/components/Comment/CommentList.jsx
@@ -29,10 +29,10 @@ export default function CommentList() {
         })
         .catch((e) => e);
     }
-  }, [auth]);
+  }, [auth.accountName, auth.token, postId]);
 
-  const goProfile = () => {
-    navigate('/profile');
+  const goProfile = (author) => {
+    navigate(`/profile/${author}`);
   };
 
   return (
@@ -49,11 +49,13 @@ export default function CommentList() {
                       src={comment.author.image}
                       className="basic-profile"
                       alt="유저프로필이미지"
-                      onClick={goProfile}
+                      onClick={() => goProfile(comment.author.accountname)}
                     />
                   </div>
                   <div className="user-name">
-                    <p onClick={goProfile}>{comment.author.username}</p>
+                    <p onClick={() => goProfile(comment.author.accountname)}>
+                      {comment.author.username}
+                    </p>
                     <span className="comment-time">· 댓글단시간</span>
                   </div>
                   <button className="moreBtn">

--- a/src/components/Profile/styled.jsx
+++ b/src/components/Profile/styled.jsx
@@ -172,7 +172,7 @@ const StyledListWrapper = styled.section`
 const StyledAlbumWrapper = styled.section`
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 7px;
   align-items: center;
   padding: 16px;
 `;

--- a/src/components/TextPost/TextPost.jsx
+++ b/src/components/TextPost/TextPost.jsx
@@ -27,25 +27,23 @@ const TextPost = ({ postData }) => {
     <>
       <StyledTextPost>
         <UserPost>
-          <div className="upload-user-box">
-            <Link to={`/profile/${postData.author.accountname}`}>
-              <UserInfo user={postData.author} />
-            </Link>
-            <button onClick={handlePostModal} className="moreBtn">
-              <img
-                src={MoreVertical}
-                alt="더보기 이미지"
-                onClick={() => {
-                  navigate(`/post/${postId}/postedit`, {
-                    state: {
-                      content: postData.content,
-                      image: postData.image,
-                    },
-                  });
-                }}
-              />
-            </button>
-          </div>
+          <Link to={`/profile/${postData.author.accountname}`}>
+            <UserInfo user={postData.author} />
+          </Link>
+          <button onClick={handlePostModal} className="moreBtn">
+            <img
+              src={MoreVertical}
+              alt="더보기 이미지"
+              onClick={() => {
+                navigate(`/post/${postId}/postedit`, {
+                  state: {
+                    content: postData.content,
+                    image: postData.image,
+                  },
+                });
+              }}
+            />
+          </button>
         </UserPost>
         <StyledPostMessage>
           <StyledPostLink to={`/post/${postData.id}`}>

--- a/src/components/TextPost/styled.jsx
+++ b/src/components/TextPost/styled.jsx
@@ -4,11 +4,7 @@ import styled from 'styled-components';
 export const StyledTextPost = styled.section`
   width: 358px;
   margin: 0 auto;
-  .upload-user-box {
-    position: relative;
-    display: flex;
-    right: 16px;
-  }
+
   span {
     font-size: ${({ theme }) => theme.fontSize.xsmall};
     color: ${({ theme }) => theme.colors.lightGray};
@@ -21,8 +17,6 @@ export const StyledPostMessage = styled.section`
 `;
 
 export const StyledPostLink = styled(Link)`
-  box-sizing: border-box;
-  display: block;
   width: 100%;
   margin-top: 16px;
   p {
@@ -39,9 +33,6 @@ export const StyledPostLink = styled(Link)`
     text-align: center;
     border: 0.5px solid #dbdbdb;
     border-radius: 10px;
-
-    /* padding: 15px 0px;
-    margin-left: -54px; */
   }
 `;
 
@@ -54,7 +45,6 @@ export const StyledHeartChat = styled.div`
 
   div {
     img {
-      /* vertical-align: top; */
       margin-right: 8px;
     }
     span {

--- a/src/components/UserInfo/styled.jsx
+++ b/src/components/UserInfo/styled.jsx
@@ -1,11 +1,9 @@
 import styled from 'styled-components';
 
 const StyledUserInfo = styled.article`
-  padding: 0px 16px;
   display: flex;
   font-size: ${({ theme }) => theme.fontSize.medium};
   gap: 12px;
-  width: 358px;
   height: 42px;
 
   .profile-box {

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -35,7 +35,7 @@ function Router() {
       <Route path="/chatroom" element={<ChatRoomPage />}></Route>
       <Route path="/profile/:userId/" element={<Outlet />}>
         <Route path="" element={<ProfilePage />} />
-        <Route path="followers/" element={<FollowersPage />} />
+        <Route path="followers" element={<FollowersPage />} />
       </Route>
       <Route path="/search" element={<SearchPage />}></Route>
       <Route path="*" element={<NotFoundPage />}></Route>


### PR DESCRIPTION
### 📝 Subject

스타일수정 및 라우터, 경로 설정

### 💻 Description

- 명세 요구사항: 스타일수정 및 라우터, 경로 설정
- 기능 설명
1. 유저프로필로 이동하기 위해 추가된 Link태그로 인해 클릭범위가 증가 아무것도 보이지 않는 빈 공간에서도 클릭이 발생하기 때문에 스타일 수정
2. CommentList에서 유저 클릭시 해당 유저의 프로필로 이동경로 수정
3. 앨범 포스트에서 사이즈가 안맞아서 두칸을 차지하는 스타일 수정

### 💽 Commits

1. 9964f2d:  UserInfo, TextPost 유저프로필로 이동하는 클릭버튼 범위 스타일수정
2. 2dd114c: 라우터 경로수정 및 CommentList에서 유저 프로필 이동경로 수정
3. fbc3a4b: AlbumPost flex아이템 gap사이즈 줄여서  3칸씩 아이템들이 차지하게 UI구성 close #108 

### 🖼 Result

1. 유저 프로필로 이동하기 위한 클릭 범위를 수정 빈공간 클릭 시 아무런 현상이 발생하지 않음.
2. CommentList에서도 유저 클릭 시 해당 유저의 프로필로 이동가능
3. 
<img width="367" alt="image" src="https://user-images.githubusercontent.com/92032081/210189806-29b9443f-6d0e-4e81-8000-6b2454e7a4d2.png">
