### PR TITLE
Feat/로그인유저에 따른 화면UI설정

### DIFF
--- a/src/components/Profile/ProfileInfo.jsx
+++ b/src/components/Profile/ProfileInfo.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Button from '../../components/Button/Button';
 import { TopBasicNav } from '../../components/Navbar/TopNavbar';
@@ -14,6 +14,8 @@ function ProfileInfo({ accountName }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
+  const [isFollow, setIsFollow] = useState(undefined);
+
   useEffect(() => {
     setLoading(true);
 
@@ -27,12 +29,63 @@ function ProfileInfo({ accountName }) {
       .then((res) => res.json())
       .then((res) => {
         setUserInfo(res.profile);
+        setIsFollow(res.profile.isfollow);
         setLoading(false);
       })
       .catch((e) => {
         setError(e);
       });
   }, [auth, accountName]);
+
+  const followAPI = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `https://mandarin.api.weniv.co.kr/profile/${accountName}/follow`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${auth.token}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+      const result = await res.json();
+
+      setIsFollow((isfollow) => !isfollow);
+      return result;
+    } catch (e) {
+      return new Error(e);
+    }
+  }, [accountName, auth.token]);
+
+  const unFollowAPI = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `https://mandarin.api.weniv.co.kr/profile/${accountName}/unfollow`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${auth.token}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+      const result = await res.json();
+
+      setIsFollow((isfollow) => !isfollow);
+      return result;
+    } catch (e) {
+      return new Error(e);
+    }
+  }, [accountName, auth.token]);
+
+  const handleFollowState = () => {
+    if (isFollow) {
+      unFollowAPI();
+    } else {
+      followAPI();
+    }
+  };
 
   if (loading) {
     return <div>Loading중입니다...</div>;
@@ -45,12 +98,11 @@ function ProfileInfo({ accountName }) {
   return (
     <StyledProfileInfo>
       <TopBasicNav />
-
       <div className="ProfileHeader">
         <p className="followers">
           <button
             onClick={() => {
-              navigate('./followers/', {
+              navigate('./followers', {
                 state: {
                   accountName,
                 },
@@ -80,24 +132,34 @@ function ProfileInfo({ accountName }) {
       </div>
 
       <div className="ProfileFooter">
-        <Link to="DM창">
-          <CircleBtn>
-            <img src={Message} alt="메시지 보내기" />
-          </CircleBtn>
-        </Link>
-        <Link to="/profilemodify">
-          <Button size="md" active={true}>
-            프로필 수정
-          </Button>
-        </Link>
-        <Link to="/campaignupload">
-          <Button size="md" active={true}>
-            활동 등록
-          </Button>
-        </Link>
-        <CircleBtn>
-          <img src={Share} alt="공유하기" />
-        </CircleBtn>
+        {auth.accountName === accountName ? (
+          <>
+            <Link to="/profilemodify">
+              <Button size="md" active={true}>
+                프로필 수정
+              </Button>
+            </Link>
+            <Link to="/campaignupload">
+              <Button size="md" active={true}>
+                활동 등록
+              </Button>
+            </Link>
+          </>
+        ) : (
+          <>
+            <Link to="DM창">
+              <CircleBtn>
+                <img src={Message} alt="메시지 보내기" />
+              </CircleBtn>
+            </Link>
+            <Button size="md" active={isFollow} onClick={handleFollowState}>
+              {isFollow ? '언팔로우' : '팔로우'}
+            </Button>
+            <CircleBtn>
+              <img src={Share} alt="공유하기" />
+            </CircleBtn>
+          </>
+        )}
       </div>
     </StyledProfileInfo>
   );

--- a/src/pages/Follow/FollowItem.jsx
+++ b/src/pages/Follow/FollowItem.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 import UserInfo from '../../components/UserInfo/UserInfo';
 import Button from '../../components/Button/Button';
@@ -8,7 +9,7 @@ function FollowItem({ user }) {
   const { auth } = useAuthContext();
   const [isFollow, setIsFollow] = useState(user.isfollow);
 
-  console.log(isFollow);
+  const loginAccountName = useLocation().state.accountName;
 
   const followAPI = useCallback(async () => {
     try {
@@ -62,10 +63,15 @@ function FollowItem({ user }) {
 
   return (
     <li>
-      <UserInfo user={user} />
-      <Button size="xsm" onClick={handleFollowState} active={isFollow}>
-        {isFollow ? '취소' : '팔로우'}
-      </Button>
+      <Link to={`/profile/${user.accountname}`}>
+        <UserInfo user={user} />
+      </Link>
+
+      {auth.accountName === loginAccountName ? (
+        <Button size="xsm" onClick={handleFollowState} active={isFollow}>
+          {isFollow ? '취소' : '팔로우'}
+        </Button>
+      ) : null}
     </li>
   );
 }


### PR DESCRIPTION
### 📝 Subject

로그인유저에 따른 화면UI 설정

### 💻 Description

- 명세 요구사항: 로그인유저에 따른 화면UI 설정
- 기능 설명: 
- 로그인한 유저의 FollowersPage
- 로그인하지않은 타계정 유저의 FollowersPage
- 로그인한 유저의 ProfilePage
- 로그인하지않은 타계정 유저의 ProfilePage
각각 다르게 UI설정하여서 브라우저 상에서 보여줌

### 💽 Commits

1. cb1d7c1 : 로그인된 유저가 아닐경우 FollowersPage에서 팔로우버튼 보여주지 않게 설정
2. 593def2 : 로그인이 되지 않는 유저의 프로필인 경우 프로필수정,활동등록 버튼이 아닌 팔로우버튼 보여주기 close #110 


### 🖼 Result

- 로그인한 유저의 ProfilePage
<img width="278" alt="image" src="https://user-images.githubusercontent.com/92032081/210190317-86940a07-a8d2-4833-acca-9032e12e52eb.png">

- 로그인한 유저의 FollowersPage
<img width="349" alt="image" src="https://user-images.githubusercontent.com/92032081/210190320-f8d6852c-9db5-4870-b7c1-6bfa35d75798.png">

- 로그인하지않은 타계정 유저의 ProfilePage
<img width="282" alt="image" src="https://user-images.githubusercontent.com/92032081/210190329-b8372dbd-e44d-44db-bf90-0d3352e45428.png">

- 로그인하지않은 타계정 유저의 FollowersPage
<img width="348" alt="image" src="https://user-images.githubusercontent.com/92032081/210190338-9419d1ce-ca88-4984-9fbf-c063fefcf6be.png">

