### PR TITLE
feat: 게시글/댓글 삭제, 신고 기능 구현

### DIFF
--- a/src/components/Comment/CommentList.jsx
+++ b/src/components/Comment/CommentList.jsx
@@ -13,6 +13,8 @@ export default function CommentList() {
   const [commentData, setCommentData] = useState([]);
   const navigate = useNavigate();
 
+  const BASEURL = 'https://mandarin.api.weniv.co.kr';
+
   useEffect(() => {
     if (auth.accountName) {
       fetch(`https://mandarin.api.weniv.co.kr/post/${postId}/comments`, {
@@ -60,6 +62,44 @@ export default function CommentList() {
     }
   };
 
+  // 댓글 삭제 함수 (추후 모달로 옮김)
+  const commentDelete = async (commentId) => {
+    const CommentDeleteReq = await fetch(
+      `${BASEURL}/post/${postId}/comments/${commentId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+    const result = await CommentDeleteReq.json();
+
+    alert(result.message);
+  };
+
+  // 댓글 신고 함수 (추후 모달로 옮김)
+  const commentReport = async (commentId) => {
+    const CommentReportReq = await fetch(
+      `${BASEURL}/post/${postId}/comments/${commentId}/report`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+    const result = await CommentReportReq.json();
+
+    if (result.report) {
+      alert(`댓글 id:${result.report.comment}가 신고되었습니다.`);
+    } else {
+      alert(result.message);
+    }
+  };
+
   return (
     <Scrollwrap>
       <StyledCommentList>
@@ -86,8 +126,15 @@ export default function CommentList() {
                     )}`}</span>
                   </div>
                   <button className="moreBtn">
-                    {/* // onClick={삭제, 신고모달 토글 }*/}
-                    <img src={MoreVertical} alt="더보기 이미지" />
+                    <img
+                      src={MoreVertical}
+                      alt="더보기 이미지"
+                      // 댓글 삭제 함수(추후 모달로 옮김)
+                      onClick={() => commentDelete(comment.id)}
+
+                      // 댓글 신고 함수(추후 모달로 옮김)
+                      // onClick={() => commentReport(comment.id)}
+                    />
                   </button>
                 </div>
                 <StyledPostMessage key={comment.id}>

--- a/src/components/TextPost/TextPost.jsx
+++ b/src/components/TextPost/TextPost.jsx
@@ -9,11 +9,15 @@ import UserInfo from '../UserInfo/UserInfo';
 import UserPost from '../UserPost/UserPost';
 import LikeCommentButton from '../LikeCommentButton/LikeCommentButton';
 import changeDate from '../../services/changeDate';
+import useAuthContext from '../../hooks/useAuthContext';
+
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
 
 const TextPost = ({ postData }) => {
   const newDate = changeDate(postData.createdAt);
   const { postId } = useParams();
   const navigate = useNavigate();
+  const { auth } = useAuthContext();
 
   const handlePostModal = useCallback(() => {
     console.log(`게시글 ${postData.id} 게시글 보여주기`);
@@ -22,6 +26,46 @@ const TextPost = ({ postData }) => {
   const handleImage = useCallback((e) => {
     e.target.src = ImageError;
   }, []);
+
+  // 게시글 삭제 함수 (추후 모달로 옮김)
+  const postDelete = async () => {
+    const PostDeletereq = await fetch(`${BASEURL}/post/${postId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-type': 'application/json',
+      },
+    });
+    const result = await PostDeletereq.json();
+
+    console.log(result);
+
+    if (result.message === '삭제되었습니다.') {
+      navigate(-1);
+    } else {
+      alert(result.message);
+    }
+  };
+
+  // 게시글 신고 함수 (추후 모달로 옮김)
+  const postReport = async () => {
+    const PostReportreq = await fetch(`${BASEURL}/post/${postId}/report`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-type': 'application/json',
+      },
+    });
+    const result = await PostReportreq.json();
+
+    console.log(result);
+
+    if (result.report) {
+      alert(`게시물 id:${result.report.post}가 신고되었습니다.`);
+    } else {
+      alert(result.message);
+    }
+  };
 
   return (
     <>
@@ -34,13 +78,24 @@ const TextPost = ({ postData }) => {
             <img
               src={MoreVertical}
               alt="더보기 이미지"
+              // 게시글 수정 OnClick (추후 모달로 옮김)
+              // onClick={() => {
+              //   navigate(`/post/${postId}/postedit`, {
+              //     state: {
+              //       content: postData.content,
+              //       image: postData.image,
+              //     },
+              //   });
+              // }}
+
+              // 게시글 삭제 OnClick (추후 모달로 옮김)
+              // onClick={() => {
+              //   postDelete();
+              // }}
+
+              // 게시글 신고 OnClick (추후 모달로 옮김)
               onClick={() => {
-                navigate(`/post/${postId}/postedit`, {
-                  state: {
-                    content: postData.content,
-                    image: postData.image,
-                  },
-                });
+                postReport();
               }}
             />
           </button>


### PR DESCRIPTION
### 📝 Subject
게시글/댓글 삭제, 신고 기능 구현

### 💻 Description
- 명세 요구사항: 
  * DELETE, POST 메서드를 사용하여 게시글/댓글을 삭제 및 신고합니다. 
- 기능 설명: 
  * Context API를 사용하여 auth 정보를 가져왔습니다. 
  * 게시글 삭제, 신고의 경우 현재 TextPost.jsx 안에 함수가 작성되어 있습니다. 추후 모달 기능이 완성되면 모달 기능 안으로 옮겨 넣으시면 됩니다. 
  * 댓글 삭제, 신고의 경우 CommentList.jsx 안에 함수가 작성되어 있습니다. 추후 모달 기능이 완성되면 모달 기능 안으로 옮겨 넣으시면 됩니다. 
  * 현재 게시글 삭제, 신고의 경우 PostPage 안으로 들어가서 메뉴버튼을 눌러야만 정상 작동됩니다. PostList 에서는 정상 작동되지 않습니다.
  * 현재 임시로 alert 메시지를 띄워 UI를 구축하였습니다.

### 💽 Commits
close #112 
1. ccbd5a5cbdea4645c6c9bceea7572f31c03de2d4 : 게시글 삭제, 신고
2. 97ba8f05d0acff6d40cd5ad0fb507be2636ca828 : 댓글 삭제, 신고

### 🖼 Result

// 게시글 삭제 성공한 경우: 즉시 뒤로가기 

![image](https://user-images.githubusercontent.com/85055608/210192342-8486a49d-cc6a-4689-a10f-0cfa734b0929.png)
// 내가 아닌 다른 사람의 게시글을 삭제하려 할 경우

![image](https://user-images.githubusercontent.com/85055608/210192249-43ae5739-eff0-4d42-b70d-af3155d6afdc.png)
// 게시글 신고 성공한 경우

![image](https://user-images.githubusercontent.com/85055608/210192279-e7d9ff95-c607-40a0-954c-995a339cd129.png)
// 게시글 id를 넘겨받지 못한 경우

![image](https://user-images.githubusercontent.com/85055608/210195667-7420691c-0ead-4af9-bd81-d7b1ca2d4380.png)
// 자신의 댓글을 삭제 성공한 경우

![image](https://user-images.githubusercontent.com/85055608/210195610-28b53101-7d63-43b7-b069-93a46c10269e.png)
// 내가 아닌 다른 사람의 댓글을 삭제하려 할 경우

![image](https://user-images.githubusercontent.com/85055608/210195554-745a553e-13df-4cdb-8e23-d9420cd2f294.png)
// 댓글 신고 성공한 경우