### PR TITLE
Style/profile 페이지 스타일링 

### DIFF
--- a/src/components/Profile/CampaignList.jsx
+++ b/src/components/Profile/CampaignList.jsx
@@ -42,7 +42,7 @@ const CampaginList = ({ accountName }) => {
   return (
     <StyledCampaginWrapper>
       <h3 className="title">
-        참여한 캠페인 목록<strong>{`(${campaignsCount}개)`}</strong>
+        참여한 캠페인<strong> {`(${campaignsCount}개)`}</strong>
       </h3>
       <StyledCampaginList>
         {campaigns.map((campaign) => (

--- a/src/components/Profile/ProfileInfo.jsx
+++ b/src/components/Profile/ProfileInfo.jsx
@@ -85,7 +85,7 @@ function ProfileInfo({ accountName }) {
       </div>
 
       <div className="ProfileFooter">
-        <Link to="DM창">
+        <Link to="/chatlist">
           <CircleBtn>
             <img src={Message} alt="메시지 보내기" />
           </CircleBtn>

--- a/src/components/Profile/ProfileInfo.jsx
+++ b/src/components/Profile/ProfileInfo.jsx
@@ -71,7 +71,7 @@ function ProfileInfo({ accountName }) {
       <div className="ProfileMain">
         <p>
           {userInfo.username}
-          <span>@{userInfo.accountname}</span>
+          <span>@ {userInfo.accountname}</span>
         </p>
       </div>
 

--- a/src/components/Profile/ProfileInfo.jsx
+++ b/src/components/Profile/ProfileInfo.jsx
@@ -42,6 +42,11 @@ function ProfileInfo({ accountName }) {
     return <div>Error메세지: {error}</div>;
   }
 
+  const shareProfile = (event) => {
+    navigator.clipboard.writeText(window.location.href);
+    alert('주소가 복사되었습니다!');
+  };
+
   return (
     <StyledProfileInfo>
       <TopBasicNav />
@@ -95,7 +100,7 @@ function ProfileInfo({ accountName }) {
             활동 등록
           </Button>
         </Link>
-        <CircleBtn>
+        <CircleBtn onClick={shareProfile}>
           <img src={Share} alt="공유하기" />
         </CircleBtn>
       </div>

--- a/src/components/Profile/styled.jsx
+++ b/src/components/Profile/styled.jsx
@@ -83,6 +83,7 @@ const StyledProfileInfo = styled.div`
       width: 110px;
       height: 110px;
       border-radius: 50%;
+      object-fit: cover;
     }
   }
 

--- a/src/components/Profile/styled.jsx
+++ b/src/components/Profile/styled.jsx
@@ -14,6 +14,10 @@ const StyledCampaginWrapper = styled.div`
     margin: 22px 0px 16px;
     font-size: ${({ theme }) => theme.fontSize.large};
     line-height: 18px;
+    font-weight: 400;
+    strong {
+      font-size: ${({ theme }) => theme.fontSize.medium};
+    }
   }
 `;
 

--- a/src/components/UserInfo/UserInfo.jsx
+++ b/src/components/UserInfo/UserInfo.jsx
@@ -21,7 +21,7 @@ function UserInfo({ user }) {
       </div>
       <div className="user-name">
         <h3>{user.username}</h3>
-        <span>{user.accountname}</span>
+        <span>@ {user.accountname}</span>
       </div>
     </StyledUserInfo>
   );

--- a/src/pages/Follow/FollowersPage.jsx
+++ b/src/pages/Follow/FollowersPage.jsx
@@ -11,6 +11,8 @@ import {
   StyledFollowersList,
   TabMenuWrap,
 } from './styled';
+import LogoGray from '../../assets/image/full-logo-gray.svg';
+import Button from '../../components/Button/Button';
 
 const FollowersPage = () => {
   const [loading, setLoading] = useState(false);
@@ -20,6 +22,10 @@ const FollowersPage = () => {
   const location = useLocation();
   const { auth } = useAuthContext();
   const accountName = location.state.accountName;
+
+  const goSearch = () => {
+    window.location.href = '/search';
+  };
 
   useEffect(() => {
     setLoading(true);
@@ -57,7 +63,13 @@ const FollowersPage = () => {
       <StyledFollowersListWrapper>
         <StyledFollowersList>
           {!followers || followers.length === 0 ? (
-            <li>팔로우 목록이 존재하지 않습니다.</li>
+            <main className="non-post">
+              <img src={LogoGray} alt="회색이미지" />
+              <span>팔로우 목록이 존재하지 않습니다.</span>
+              <Button size="md" onClick={goSearch}>
+                검색하기
+              </Button>
+            </main>
           ) : (
             followers.map((follower) => (
               <FollowItem user={follower} key={follower._id} />

--- a/src/pages/Follow/styled.jsx
+++ b/src/pages/Follow/styled.jsx
@@ -35,6 +35,20 @@ const StyledFollowersList = styled.ul`
       height: 28px;
     }
   }
+
+  .non-post {
+    width: 390px;
+    /* height: 712px; */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 200px;
+    span {
+      margin: 20px;
+      font-size: ${({ theme }) => theme.fontSize.medium};
+      color: #767676;
+    }
+  }
 `;
 
 const TabMenuWrap = styled.div`

--- a/src/pages/Search/SearchPage.jsx
+++ b/src/pages/Search/SearchPage.jsx
@@ -59,7 +59,6 @@ function Search() {
         inputtype="text"
         onChange={(e) => {
           setKeyword(e.target.value);
-          console.log('as');
         }}
       />
       <main className="searchMain">


### PR DESCRIPTION
### 📝 Subject

- profile 페이지의 스타일을 재수정 합니다.

### 💻 Description

- 기능 설명 : 피그마와 비교하여 다른 부분을 수정이 필요한 곳을 재스타일링

### 💽 Commits

close #107 
1. 5f1cb87 : UserInfo 및 ProfileInfo의 '@ name'으로 수정
2. 8e7ba47 : 팔로우한 유저가 없을 시의 페이지 스타일링 및 search 페이지 연결
3. 66c6d69: 참여한 캠페인 목록' title 수정
4. f00569b : 공유하기 버튼 연결 기능 활성화
5. 25bb156 : chat 아이콘을 '/chatlist'로 연결
6. profile 의 이미지 cover style 수정

