### PR TITLE
Feat/모달창추가기능및Comment, Campaign, ChatRoom 모달추가

### DIFF
--- a/src/components/CampaignCard/CampaignCard.jsx
+++ b/src/components/CampaignCard/CampaignCard.jsx
@@ -1,27 +1,16 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import CampaignCardWrapper from './styled';
+import ModalButton from '../Modal/ModalButton';
 
 export default function CampaginCard({ campaign }) {
-  const navigate = useNavigate();
-
   return (
     <CampaignCardWrapper>
-      <img
-        src={campaign.itemImage}
-        alt={campaign.itemName}
-        // 아래 기능은 모달 적용 유무에 따라 처리 의논.
-        onClick={() => {
-          navigate(`/campaign/${campaign.id}/edit`, {
-            state: {
-              id: campaign.id,
-            },
-          });
-        }}
-      />
+      <ModalButton modalType="CampaignModal" campaign={campaign}>
+        <img src={campaign.itemImage} alt={campaign.itemName} />
+      </ModalButton>
       <p>{campaign.itemName}</p>
       <p>
-        <span>현재 진행 중</span>
+        <span>{`참가인원 ${campaign.price}명`}</span>
       </p>
     </CampaignCardWrapper>
   );

--- a/src/components/CampaignCard/styled.jsx
+++ b/src/components/CampaignCard/styled.jsx
@@ -6,15 +6,11 @@ const CampaignCardWrapper = styled.li`
   list-style: none;
   flex-shrink: 0;
 
-  a {
-    display: block;
-    width: 100%;
-  }
-
   img {
-    width: 100%;
+    object-fit: cover;
+    width: 140px;
     height: 90px;
-    border: 0.5px solid #bdbdbd;
+    border: 0.5px solid ${({ theme }) => theme.colors.ActiveborderColor};
     border-radius: 8px;
   }
 

--- a/src/components/Modal/Alert/CampaignAlert.jsx
+++ b/src/components/Modal/Alert/CampaignAlert.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import useAuthContext from '../../../hooks/useAuthContext';
+import {
+  StyledAlertButtons,
+  StyledAlertTextButton,
+  StyledWrapper,
+} from './styled';
+
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
+
+export default function CampaignAlert({ handleCloseAlert, campaignId }) {
+  const { auth } = useAuthContext();
+
+  const handleDeleteCampaign = () => {
+    campaginDelete();
+  };
+
+  const campaginDelete = async () => {
+    const CampaignDeleteReq = await fetch(`${BASEURL}/product/${campaignId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${auth.token}`,
+        'Content-type': 'application/json',
+      },
+    });
+
+    const result = await CampaignDeleteReq.json();
+
+    if (result.message === '삭제되었습니다.') {
+      location.reload();
+    } else {
+      alert(result.message);
+    }
+  };
+
+  return (
+    <StyledWrapper>
+      <StyledAlertTextButton>캠페인을 삭제할까요?</StyledAlertTextButton>
+      <StyledAlertButtons>
+        <button onClick={handleCloseAlert}>취소</button>
+        <button onClick={handleDeleteCampaign}>삭제</button>
+      </StyledAlertButtons>
+    </StyledWrapper>
+  );
+}

--- a/src/components/Modal/Alert/CommentAlert.jsx
+++ b/src/components/Modal/Alert/CommentAlert.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import useAuthContext from '../../../hooks/useAuthContext';
+import {
+  StyledAlertButtons,
+  StyledAlertTextButton,
+  StyledWrapper,
+} from './styled';
+
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
+
+export default function CommentAlert({
+  handleCloseAlert,
+  postId,
+  commentId,
+  updateCommentData,
+}) {
+  const { auth } = useAuthContext();
+
+  const handleDeleteComment = () => {
+    commentDelete();
+  };
+
+  const commentDelete = async () => {
+    const CommentDeleteReq = await fetch(
+      `${BASEURL}/post/${postId}/comments/${commentId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+    const result = await CommentDeleteReq.json();
+
+    if (result.message === '댓글이 삭제되었습니다.') {
+      updateCommentData();
+    }
+  };
+
+  return (
+    <StyledWrapper>
+      <StyledAlertTextButton>댓글을 삭제할까요?</StyledAlertTextButton>
+      <StyledAlertButtons>
+        <button onClick={handleCloseAlert}>취소</button>
+        <button onClick={handleDeleteComment}>삭제</button>
+      </StyledAlertButtons>
+    </StyledWrapper>
+  );
+}

--- a/src/components/Modal/Alert/PostAlert.jsx
+++ b/src/components/Modal/Alert/PostAlert.jsx
@@ -20,14 +20,14 @@ export default function PostAlert({ handleCloseAlert, postId }) {
   };
 
   const postDelete = async () => {
-    const PostDeletereq = await fetch(`${BASEURL}/post/${postId}`, {
+    const PostDeleteReq = await fetch(`${BASEURL}/post/${postId}`, {
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${auth.token}`,
         'Content-type': 'application/json',
       },
     });
-    const result = await PostDeletereq.json();
+    const result = await PostDeleteReq.json();
 
     if (result.message === '삭제되었습니다.') {
       if (currentLocation.pathname === `/post/${postId}`) {

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
 import ModalPortal from './ModalPortal';
+import CampaignModal from './ModalType/CampaignModal';
 import ChatRoomModal from './ModalType/ChatRoomModal';
 import CommentModal from './ModalType/CommentModal';
 import PostModal from './ModalType/PostModal';
 import UserModal from './ModalType/UserModal';
 import { StyledBox, StyledModal, StyledModalList } from './styled';
 
-export default function Modal({ handleCloseModal, modalType, postData }) {
+export default function Modal({
+  handleCloseModal,
+  modalType,
+  postData,
+  campaign,
+  comment,
+  updateCommentData,
+}) {
   const chooseModal = () => {
     switch (modalType) {
       case 'UserModal':
@@ -15,9 +23,16 @@ export default function Modal({ handleCloseModal, modalType, postData }) {
       case 'ChatRoomModal':
         return <ChatRoomModal />;
       case 'CommentModal':
-        return <CommentModal />;
+        return (
+          <CommentModal
+            comment={comment}
+            updateCommentData={updateCommentData}
+          />
+        );
       case 'PostModal':
         return <PostModal postData={postData} />;
+      case 'CampaignModal':
+        return <CampaignModal campaign={campaign} />;
       default:
         return <>잘못된 모달창입니다.</>;
     }

--- a/src/components/Modal/ModalButton.jsx
+++ b/src/components/Modal/ModalButton.jsx
@@ -1,7 +1,14 @@
 import React, { useState } from 'react';
 import Modal from '../Modal/Modal';
 
-export default function ModalButton({ children, modalType, postData }) {
+export default function ModalButton({
+  children,
+  modalType,
+  postData,
+  campaign,
+  comment,
+  updateCommentData,
+}) {
   const [isOpenModal, setIsOpenModal] = useState(false);
   const handleOpenModal = () => {
     setIsOpenModal(true);
@@ -19,6 +26,9 @@ export default function ModalButton({ children, modalType, postData }) {
           handleCloseModal={handleCloseModal}
           modalType={modalType}
           postData={postData}
+          campaign={campaign}
+          comment={comment}
+          updateCommentData={updateCommentData}
         >
           {children}
         </Modal>

--- a/src/components/Modal/ModalType/CampaignModal.jsx
+++ b/src/components/Modal/ModalType/CampaignModal.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import useAuthContext from '../../../hooks/useAuthContext';
+import CampaignAlert from '../Alert/CampaignAlert';
+
+function CampaignModal({ campaign }) {
+  const { auth } = useAuthContext();
+  const [isOpenAlert, setIsOpenAlert] = useState(false);
+
+  const handleOpenAlert = () => {
+    setIsOpenAlert(true);
+  };
+  const handleCloseAlert = () => {
+    setIsOpenAlert(false);
+  };
+
+  return (
+    <>
+      {auth.accountName === campaign.author.accountname ? (
+        <>
+          <li>
+            <button onClick={handleOpenAlert}>캠페인 삭제</button>
+          </li>
+          <li>
+            <Link
+              to={`/campaign/${campaign.id}/edit`}
+              state={{ id: campaign.id }}
+            >
+              캠페인 수정
+            </Link>
+          </li>
+        </>
+      ) : null}
+
+      <li>
+        <a href={campaign.link}>캠페인 링크로 이동하기</a>
+      </li>
+      {isOpenAlert && (
+        <CampaignAlert
+          handleCloseAlert={handleCloseAlert}
+          campaignId={campaign.id}
+        />
+      )}
+    </>
+  );
+}
+
+export default CampaignModal;

--- a/src/components/Modal/ModalType/CommentModal.jsx
+++ b/src/components/Modal/ModalType/CommentModal.jsx
@@ -1,7 +1,15 @@
 import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import useAuthContext from '../../../hooks/useAuthContext';
+import CommentAlert from '../Alert/CommentAlert';
 
-function CommentModal() {
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
+
+function CommentModal({ comment, updateCommentData }) {
+  const { auth } = useAuthContext();
   const [isOpenAlert, setIsOpenAlert] = useState(false);
+
+  const postId = useParams().postId;
 
   const handleOpenAlert = () => {
     setIsOpenAlert(true);
@@ -9,13 +17,49 @@ function CommentModal() {
   const handleCloseAlert = () => {
     setIsOpenAlert(false);
   };
+  const handleCommentDeclartion = () => {
+    commentDeclaration();
+  };
+
+  const commentDeclaration = async () => {
+    const CommentDeclarationReq = await fetch(
+      `${BASEURL}/post/${postId}/comments/${comment.id}/report`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+    const result = await CommentDeclarationReq.json();
+
+    if (result.report) {
+      alert(`댓글 id:${result.report.comment}가 신고되었습니다.`);
+    } else {
+      alert(result.message);
+    }
+  };
 
   return (
     <>
-      <ul>
-        <li>댓글 삭제</li>
-        <li>댓글 신고</li>
-      </ul>
+      {auth.accountName === comment.author.accountname ? (
+        <li>
+          <button onClick={handleOpenAlert}>댓글 삭제</button>
+        </li>
+      ) : null}
+
+      <li>
+        <button onClick={handleCommentDeclartion}>댓글 신고</button>
+      </li>
+      {isOpenAlert && (
+        <CommentAlert
+          handleCloseAlert={handleCloseAlert}
+          commentId={comment.id}
+          updateCommentData={updateCommentData}
+          postId={postId}
+        />
+      )}
     </>
   );
 }

--- a/src/components/Modal/ModalType/PostModal.jsx
+++ b/src/components/Modal/ModalType/PostModal.jsx
@@ -4,6 +4,8 @@ import useAuthContext from '../../../hooks/useAuthContext';
 
 import PostAlert from '../Alert/PostAlert';
 
+const BASEURL = 'https://mandarin.api.weniv.co.kr';
+
 function PostModal({ postData }) {
   const { auth } = useAuthContext();
   const [isOpenAlert, setIsOpenAlert] = useState(false);
@@ -13,6 +15,30 @@ function PostModal({ postData }) {
   };
   const handleCloseAlert = () => {
     setIsOpenAlert(false);
+  };
+
+  const handlePostDeclaration = () => {
+    postDeclaration();
+  };
+
+  const postDeclaration = async () => {
+    const PostDeclarationReq = await fetch(
+      `${BASEURL}/post/${postData.id}/report`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+          'Content-type': 'application/json',
+        },
+      }
+    );
+    const result = await PostDeclarationReq.json();
+
+    if (result.report) {
+      alert(`게시물 id:${result.report.post}가 신고되었습니다.`);
+    } else {
+      alert(result.message);
+    }
   };
 
   return (
@@ -33,7 +59,9 @@ function PostModal({ postData }) {
         </>
       ) : null}
 
-      <li>게시글 신고</li>
+      <li>
+        <button onClick={handlePostDeclaration}>게시글 신고</button>
+      </li>
       {isOpenAlert && (
         <PostAlert handleCloseAlert={handleCloseAlert} postId={postData.id} />
       )}

--- a/src/components/Navbar/TopNavbar.jsx
+++ b/src/components/Navbar/TopNavbar.jsx
@@ -28,6 +28,23 @@ export function TopBasicNav(props) {
   );
 }
 
+export function TopChatNav(props) {
+  const navigate = useNavigate();
+  const handleGoBack = () => {
+    navigate(-1);
+  };
+
+  return (
+    <StyledTopBasicNav>
+      <img src={iconArrowLeft} alt="뒤로가기" onClick={handleGoBack} />
+      <span>{props.value}</span>
+      <ModalButton modalType={'ChatRoomModal'}>
+        <img src={iconMoreVerticalLarge} alt="메뉴" />
+      </ModalButton>
+    </StyledTopBasicNav>
+  );
+}
+
 export function TopSearchNav({ onChange, value }) {
   const navigate = useNavigate();
   const handleGoBack = () => {

--- a/src/pages/Chat/ChatRoomPage.jsx
+++ b/src/pages/Chat/ChatRoomPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyledChatPage, StyledChatRoomInput } from './styled';
-import { TopBasicNav } from '../../components/Navbar/TopNavbar';
-import CommentInput from './../../components/Comment/CommentInput';
+import { TopChatNav } from '../../components/Navbar/TopNavbar';
+
 import Button from '../../components/Button/Button';
 
 import uploadImg from '../../assets/icon/icon-img-button-gray.svg';
@@ -9,7 +9,7 @@ import uploadImg from '../../assets/icon/icon-img-button-gray.svg';
 export default function ChatRoomPage() {
   return (
     <StyledChatPage>
-      <TopBasicNav value="Chat" />
+      <TopChatNav value="Chat" />
       <StyledChatRoomInput>
         <img src={uploadImg} alt="" />
         <input type="text" placeholder="메시지 입력하기..." />


### PR DESCRIPTION
### 📝 Subject

모달창추가기능및Comment, Campaign, ChatRoom 모달추

### 💻 Description

- 명세 요구사항: 모달창추가기능및Comment, Campaign, ChatRoom 모달추
- 기능 설명
1. Campaign 모달창 생성 및 해당 Alert창을 띄운 후 삭제기능 추가, Campaign모달창에서 수정페이지 이동, Url로 이동 버튼 추가
2. Comment 모달창 생성, 해당 Alert창을 띄운 후 삭제기능 추가, Comment모달창에서 신고기능 추가
3. ChatRoom 모달창 생성, 해당 모달창을 띄우기 위해 TopNavbar컴포넌트에서 TopChatNav컴포넌트 생성 후 나가기 버튼 추가
4. 해당 로그인 된 유저가 아닌 경우 캠페인 삭제, 수정, 댓글 삭제 등이 불가능 하도록 설정

### 💽 Commits
1. fdd96a9: CampaginCard컴포넌트 Campaign모달창을 띄우기 위해서 연결 및 스타일 수정
2. 4866bc3: CampaignModal 컴포넌트 생성
3. 1772695: Campaign모달창에서 CampaignAlert컴포넌트 연결 및 생성
4. dfc3c91:  ChatRoom모달창을 띄우기 위해 새로운 TopChatNav생성, ChatRoomPage TopNavbar변경 및 
스타일 수정
5. e7671a4: CommentModal, CommentAlert컴포넌트 생성 및 기능추가
6. c9722a8: PostModal컴포넌트에서 신고기능 추가
7. 4fe4634: Modal, ModalButton컴포넌트 props 받아온 후 ModalType에 따라 설정 close #129 


### 🖼 Result

1. 로그인 된  유저가 아닌 댓글 모달창
<img width="390" alt="image" src="https://user-images.githubusercontent.com/92032081/210310257-4532f17e-6e41-43be-887c-29332803f455.png">

2. 로그인 된 유저의 댓글 모달창
<img width="385" alt="image" src="https://user-images.githubusercontent.com/92032081/210310326-7e102154-5db7-4e14-b5bc-7d71bb8993ec.png">

3. 로그인 된 유저의 캠페인 모달창
<img width="386" alt="image" src="https://user-images.githubusercontent.com/92032081/210310455-3a33b218-d999-431d-b53b-031eb7f87b9c.png">

4. 로그인 된 유저가 아닌 캠페인 모달창
<img width="380" alt="image" src="https://user-images.githubusercontent.com/92032081/210310503-1448fc8d-91cd-4621-8311-bac605b7c0d7.png">

5. 댓글 삭제 Alert창
<img width="248" alt="image" src="https://user-images.githubusercontent.com/92032081/210310405-795a595a-a526-4c84-9180-04b4f9587029.png">

6. 채팅방 나가기 모달창
<img width="383" alt="image" src="https://user-images.githubusercontent.com/92032081/210310567-bfe15725-4db7-4337-b04e-8af5bf4ccfb7.png">
