### PR TITLE
Fix/ProfileInfo컴포넌트followerscount오류수정

### DIFF
--- a/src/components/Profile/ProfileInfo.jsx
+++ b/src/components/Profile/ProfileInfo.jsx
@@ -13,6 +13,7 @@ function ProfileInfo({ accountName }) {
   const [userInfo, setUserInfo] = useState({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [followersCount, setFollowersCount] = useState(undefined);
 
   const accountId = userInfo.accountname;
   const [isFollow, setIsFollow] = useState(undefined);
@@ -53,6 +54,7 @@ function ProfileInfo({ accountName }) {
       const result = await res.json();
 
       setIsFollow((isfollow) => !isfollow);
+      setFollowersCount(result.profile.followerCount);
       return result;
     } catch (e) {
       return new Error(e);
@@ -74,6 +76,7 @@ function ProfileInfo({ accountName }) {
       const result = await res.json();
 
       setIsFollow((isfollow) => !isfollow);
+      setFollowersCount(result.profile.followerCount);
       return result;
     } catch (e) {
       return new Error(e);
@@ -115,7 +118,9 @@ function ProfileInfo({ accountName }) {
               });
             }}
           >
-            {userInfo.followerCount}
+            {followersCount === undefined
+              ? userInfo.followerCount
+              : followersCount}
           </button>
           <span>followers</span>
         </p>

--- a/src/pages/Follow/FollowItem.jsx
+++ b/src/pages/Follow/FollowItem.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import UserInfo from '../../components/UserInfo/UserInfo';
 import Button from '../../components/Button/Button';
@@ -8,8 +8,6 @@ import useAuthContext from '../../hooks/useAuthContext';
 function FollowItem({ user }) {
   const { auth } = useAuthContext();
   const [isFollow, setIsFollow] = useState(user.isfollow);
-
-  const loginAccountName = useLocation().state.accountName;
 
   const followAPI = useCallback(async () => {
     try {
@@ -67,11 +65,9 @@ function FollowItem({ user }) {
         <UserInfo user={user} />
       </Link>
 
-      {auth.accountName === loginAccountName ? (
-        <Button size="xsm" onClick={handleFollowState} active={isFollow}>
-          {isFollow ? '취소' : '팔로우'}
-        </Button>
-      ) : null}
+      <Button size="xsm" onClick={handleFollowState} active={isFollow}>
+        {isFollow ? '취소' : '팔로우'}
+      </Button>
     </li>
   );
 }


### PR DESCRIPTION
### 📝 Subject

ProfileInfo 컴포넌트에서 팔로우버튼 클릭시 카운트 렌더링 오류

### 💻 Description

- 명세 요구사항: ProfileInfo 컴포넌트에서 팔로우버튼 클릭시 카운트 렌더링 오류

- 기능 설명
- 로그인된 유저의 프로필페이지가 아닌 다른 사람의 프로필 페이지로 이동한 경우 팔로우/언팔로우 버튼 클릭 시 렌더링 이슈 해결
- FollowersCount state를 새로 추가하여 다시 렌더링이 발생하도록 설정하였습니다.
- 초기상태인 followerpage에서 로그인된 유저가 아닌 다른 유저의 followerpage에 들어간 경우 팔로우 버튼을 보여주지 않는 방식으로 진행하였는데 논리적 오류로 해당사항을 원래의 상태인 팔로우버튼을 모두 보여주는 형식으로 변경하였습니다.

### 💽 Commits

1. 87bdb28: ProfileInfo컴포넌트에서 팔로우 버튼클릭 시 followersCount렌더링 이슈해결
2. 4837e38: 팔로워페이지에서 로그인된 유저만 팔로우 버튼을 보여주는 것이 아닌 모두 보여주는 것으로 수정 close #134 

### 🖼 Result

ex) 실행, 테스트 결과 또는 사진 첨부
